### PR TITLE
ci: prepare the v1.0.0 release path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule: { interval: weekly }
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: /
     schedule: { interval: weekly }

--- a/.github/scripts/check-dco.sh
+++ b/.github/scripts/check-dco.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Impulsa SLU
+
+# Require a DCO sign-off from every non-merge commit. Human sign-offs must match the commit author or
+# committer. Dependabot's canonical support@github.com sign-off is accepted only when both the PR event
+# and GitHub's signed-commit metadata independently identify the canonical Dependabot service.
+set -uo pipefail
+
+: "${BASE:?BASE must identify the pull request base commit}"
+: "${HEAD:?HEAD must identify the pull request head commit}"
+
+verified_dependabot_commit() {
+  local sha=$1
+  local author_email=$2
+  local committer_email=$3
+  local commit_json
+
+  [ "${PR_AUTHOR:-}" = 'dependabot[bot]' ] || return 1
+  [ "$author_email" = '49699333+dependabot[bot]@users.noreply.github.com' ] || return 1
+  [ "$committer_email" = 'noreply@github.com' ] || return 1
+  [ -n "${GITHUB_REPOSITORY:-}" ] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+
+  if ! commit_json=$(gh api "repos/$GITHUB_REPOSITORY/commits/$sha"); then
+    return 1
+  fi
+
+  jq -e '
+    .author.login == "dependabot[bot]" and
+    .committer.login == "web-flow" and
+    .verification.verified == true and
+    .verification.reason == "valid"
+  ' >/dev/null <<< "$commit_json"
+}
+
+ok=1
+while read -r sha; do
+  # Merge commits do not represent a new contributor assertion.
+  if [ "$(git rev-list --parents -n1 "$sha" | wc -w)" -gt 2 ]; then
+    continue
+  fi
+
+  author_email=$(git show -s --format='%ae' "$sha" | tr '[:upper:]' '[:lower:]')
+  committer_email=$(git show -s --format='%ce' "$sha" | tr '[:upper:]' '[:lower:]')
+  mapfile -t signoff_emails < <(
+    git show -s --format='%B' "$sha" \
+      | awk '
+          { line[NR] = $0 }
+          END {
+            last = NR
+            while (last > 0 && line[last] ~ /^[[:space:]]*$/) last--
+            first = last
+            while (first > 0 && line[first] !~ /^[[:space:]]*$/) first--
+            for (i = first + 1; i <= last; i++) print line[i]
+          }
+        ' \
+      | grep -iE '^Signed-off-by:[[:space:]]*.+<[^>]+>[[:space:]]*$' \
+      | grep -ioE '<[^>]+>' \
+      | tr -d '<>' \
+      | tr '[:upper:]' '[:lower:]'
+  )
+
+  if [ "${#signoff_emails[@]}" -eq 0 ]; then
+    echo "::error::commit ${sha:0:8} has no Signed-off-by — run: git commit --amend -s --no-edit"
+    ok=0
+    continue
+  fi
+
+  email_match=0
+  canonical_dependabot_signoff=0
+  for email in "${signoff_emails[@]}"; do
+    if [ "$email" = "$author_email" ] || [ "$email" = "$committer_email" ]; then
+      email_match=1
+    fi
+    if [ "$email" = 'support@github.com' ]; then
+      canonical_dependabot_signoff=1
+    fi
+  done
+
+  if [ "$email_match" -eq 1 ]; then
+    continue
+  fi
+  if [ "$canonical_dependabot_signoff" -eq 1 ] \
+    && verified_dependabot_commit "$sha" "$author_email" "$committer_email"; then
+    continue
+  fi
+
+  echo "::error::commit ${sha:0:8} has no sign-off matching author <$author_email> or committer <$committer_email>"
+  ok=0
+done < <(git rev-list "$BASE..$HEAD")
+
+if [ "$ok" -eq 1 ]; then
+  echo "✅ DCO: all commits signed off"
+else
+  exit 1
+fi

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -17,7 +17,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false

--- a/.github/workflows/capacity.yml
+++ b/.github/workflows/capacity.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,9 +3,9 @@ on:
   pull_request:
     branches: [main]
 
-# Verifies every non-merge commit in the PR carries a Signed-off-by trailer (DCO 1.1) whose email
-# matches the commit author or committer. Pure bash + the official checkout action — no third-party
-# action in the trust path. See CONTRIBUTING.md / DCO.
+# Verifies every non-merge commit in the PR carries a valid Signed-off-by trailer (DCO 1.1). The
+# canonical Dependabot sign-off is accepted only after GitHub independently verifies the bot and commit.
+# Official GitHub tooling only — no third-party action in the trust path. See CONTRIBUTING.md / DCO.
 permissions:
   contents: read
 
@@ -13,37 +13,14 @@ jobs:
   dco:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check Signed-off-by on every commit
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -uo pipefail
-          ok=1
-          for sha in $(git rev-list "$BASE..$HEAD"); do
-            # skip merge commits (more than one parent)
-            if [ "$(git rev-list --parents -n1 "$sha" | wc -w)" -gt 2 ]; then
-              continue
-            fi
-            ae=$(git show -s --format='%ae' "$sha" | tr '[:upper:]' '[:lower:]')
-            ce=$(git show -s --format='%ce' "$sha" | tr '[:upper:]' '[:lower:]')
-            mapfile -t emails < <(git show -s --format='%B' "$sha" \
-              | grep -ioE '^Signed-off-by:[[:space:]]*.+<[^>]+>' \
-              | grep -ioE '<[^>]+>' | tr -d '<>' | tr '[:upper:]' '[:lower:]')
-            if [ "${#emails[@]}" -eq 0 ]; then
-              echo "::error::commit ${sha:0:8} has no Signed-off-by — run: git commit --amend -s --no-edit"
-              ok=0; continue
-            fi
-            match=0
-            for e in "${emails[@]}"; do
-              [ "$e" = "$ae" ] || [ "$e" = "$ce" ] && match=1
-            done
-            if [ "$match" -ne 1 ]; then
-              echo "::error::commit ${sha:0:8} Signed-off-by does not match author <$ae> — sign off as yourself"
-              ok=0
-            fi
-          done
-          if [ "$ok" -eq 1 ]; then echo "✅ DCO: all commits signed off"; else exit 1; fi
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/check-dco.sh

--- a/.github/workflows/deps-audit.yml
+++ b/.github/workflows/deps-audit.yml
@@ -11,7 +11,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           submodules: recursive
@@ -56,7 +56,7 @@ jobs:
           upload-release-assets: false
       - name: Attach the source SBOM attestation
         id: source-attestation
-        uses: actions/attest@c32b4b8b198b65d0bd9d63490e847ff7b53989d4 # v4.0.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: ${{ runner.temp }}/source-release/burnerpad-lite-source-${{ github.event.workflow_run.head_sha }}.tar.gz
           sbom-path: ${{ runner.temp }}/source-release/burnerpad-lite-source-${{ github.event.workflow_run.head_sha }}.spdx.json
@@ -69,7 +69,12 @@ jobs:
           dist="$RUNNER_TEMP/source-release"
           archive="$dist/burnerpad-lite-source-$REVISION.tar.gz"
           cp "$ATTESTATION_BUNDLE" "$dist/burnerpad-lite-source-$REVISION.attestation.json"
-          gh attestation verify "$archive" --repo "$GITHUB_REPOSITORY"
+          gh attestation verify "$archive" \
+            --repo "$GITHUB_REPOSITORY" \
+            --bundle "$ATTESTATION_BUNDLE" \
+            --predicate-type https://spdx.dev/Document/v2.3 \
+            --cert-identity "https://github.com/$GITHUB_REPOSITORY/.github/workflows/release.yml@refs/heads/main" \
+            --deny-self-hosted-runners
           (cd "$dist" && sha256sum -- * > SHA256SUMS)
       - name: Archive the source release, SPDX SBOM, and attestation
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -101,7 +106,7 @@ jobs:
             dockerfile: ops/cloudflared.Dockerfile
             version: tunnel
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           submodules: recursive
@@ -126,15 +131,15 @@ jobs:
           echo "image=$image" >> "$GITHUB_OUTPUT"
           echo "tag=$image:sha-$REVISION" >> "$GITHUB_OUTPUT"
           echo "version=$component_version" >> "$GITHUB_OUTPUT"
-      - uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Build and publish ${{ matrix.version }} image
         id: build
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -179,7 +184,7 @@ jobs:
             result: "passed"
           }' > "$PREDICATE_PATH"
       - name: Attach the passed vulnerability-scan attestation
-        uses: actions/attest@c32b4b8b198b65d0bd9d63490e847ff7b53989d4 # v4.0.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ${{ steps.identity.outputs.image }}
           subject-digest: ${{ steps.build.outputs.digest }}
@@ -187,7 +192,7 @@ jobs:
           predicate-path: ${{ runner.temp }}/trivy-scan-predicate.json
           push-to-registry: true
       - name: Attach GitHub build-provenance attestation
-        uses: actions/attest@c32b4b8b198b65d0bd9d63490e847ff7b53989d4 # v4.0.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ${{ steps.identity.outputs.image }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       # The crypto bundle is the crypto-js submodule. `submodules: recursive` fetches it with the
       # repo-scoped GITHUB_TOKEN — which works once crypto-js is PUBLIC. While it is private, supply a
       # token with read access here (e.g. `token: ${{ secrets.CRYPTO_JS_PAT }}`) or a deploy key.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
   browser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 0
@@ -117,7 +117,7 @@ jobs:
   images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 0
@@ -184,7 +184,7 @@ jobs:
   ops:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
@@ -251,12 +251,14 @@ jobs:
           koalaman/shellcheck-alpine:v0.11.0@sha256:9955be09ea7f0dbf7ae942ac1f2094355bb30d96fffba0ec09f5432207544002
           shellcheck .githooks/pre-commit .github/scripts/check-toolchain-pins.sh
           .github/scripts/check-clean-tree.sh .github/scripts/check-crypto-release.sh
+          .github/scripts/check-dco.sh
           .github/scripts/package-source.sh
           .github/scripts/reconcile-durable-issue.sh
           ops/check-security-claims.sh ops/install-requirements-locked.sh
           test/ci/image_cookie_scanner_test.sh test/ci/image_cookie_test.sh
           test/ci/production_runtime_hardening_test.sh
           test/ci/clean_tree_test.sh
+          test/ci/dco_test.sh
           test/load/run_capacity_profile.sh test/load/run_capacity_matrix.sh
           test/ci/compose_project_identity_test.sh test/ci/install_requirements_locked_test.sh
           test/ci/reconcile_durable_issue_test.sh test/ci/runtime_credentials_test.sh
@@ -268,6 +270,8 @@ jobs:
         run: test/ci/compose_project_identity_test.sh
       - name: Test source release packaging
         run: test/ci/source_release_test.sh
+      - name: Test DCO policy
+        run: test/ci/dco_test.sh
       - name: Test strict clean-tree detection
         run: bash test/ci/clean_tree_test.sh
       - name: Test durable-issue reconciliation

--- a/test/ci/dco_test.sh
+++ b/test/ci/dco_test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Impulsa SLU
+
+set -euo pipefail
+
+test_dir=$(cd "$(dirname "$0")" && pwd)
+repo_dir=$(cd "$test_dir/../.." && pwd)
+checker="$repo_dir/.github/scripts/check-dco.sh"
+scratch=$(mktemp -d)
+
+cleanup() {
+  find "$scratch" -depth -delete
+}
+trap cleanup EXIT
+
+# Imported by the checker process as a local adapter for GitHub's commits API.
+CASE_HEAD=
+MOCK_COMMIT_JSON=
+export CASE_HEAD MOCK_COMMIT_JSON
+gh() {
+  if [ "$1" != api ] || [ "$2" != "repos/example/burnerpad/commits/$CASE_HEAD" ]; then
+    return 2
+  fi
+  printf '%s\n' "$MOCK_COMMIT_JSON"
+}
+export -f gh
+
+create_case() {
+  local name=$1
+
+  case_repo="$scratch/$name"
+  git -C "$scratch" init -q "$name"
+  git -C "$case_repo" config user.name "DCO policy test"
+  git -C "$case_repo" config user.email "policy@example.invalid"
+  git -C "$case_repo" -c commit.gpgsign=false commit --allow-empty --no-gpg-sign -qm base
+  case_base=$(git -C "$case_repo" rev-parse HEAD)
+}
+
+add_commit() {
+  local author_name=$1
+  local author_email=$2
+  local committer_name=$3
+  local committer_email=$4
+  local signoff_email=${5-}
+  local text_after_signoff=${6-}
+  local -a commit_args
+
+  printf '%s\n' "$author_name" > "$case_repo/change.txt"
+  git -C "$case_repo" add change.txt
+  if [ -n "$signoff_email" ]; then
+    commit_args=(-qm change -m "Signed-off-by: $author_name <$signoff_email>")
+    if [ -n "$text_after_signoff" ]; then
+      commit_args+=(-m "$text_after_signoff")
+    fi
+    GIT_AUTHOR_NAME="$author_name" GIT_AUTHOR_EMAIL="$author_email" \
+      GIT_COMMITTER_NAME="$committer_name" GIT_COMMITTER_EMAIL="$committer_email" \
+      git -C "$case_repo" -c commit.gpgsign=false commit --no-gpg-sign "${commit_args[@]}"
+  else
+    GIT_AUTHOR_NAME="$author_name" GIT_AUTHOR_EMAIL="$author_email" \
+      GIT_COMMITTER_NAME="$committer_name" GIT_COMMITTER_EMAIL="$committer_email" \
+      git -C "$case_repo" -c commit.gpgsign=false commit --no-gpg-sign -qm change
+  fi
+  case_head=$(git -C "$case_repo" rev-parse HEAD)
+}
+
+run_checker() {
+  local pr_author=$1
+  local commit_json=${2-'{}'}
+
+  (
+    cd "$case_repo"
+    env \
+      BASE="$case_base" \
+      HEAD="$case_head" \
+      PR_AUTHOR="$pr_author" \
+      GITHUB_REPOSITORY=example/burnerpad \
+      GH_TOKEN=test-token \
+      CASE_HEAD="$case_head" \
+      MOCK_COMMIT_JSON="$commit_json" \
+      "$checker"
+  )
+}
+
+expect_pass() {
+  local label=$1
+  local output
+  shift
+
+  if ! output=$(run_checker "$@" 2>&1); then
+    printf 'expected %s to pass:\n%s\n' "$label" "$output" >&2
+    exit 1
+  fi
+}
+
+expect_fail() {
+  local label=$1
+  local output
+  shift
+
+  if output=$(run_checker "$@" 2>&1); then
+    printf 'expected %s to fail:\n%s\n' "$label" "$output" >&2
+    exit 1
+  fi
+}
+
+create_case human-match
+add_commit Alice alice@example.com Alice alice@example.com alice@example.com
+expect_pass "matching human sign-off" alice
+
+create_case human-mismatch
+add_commit Alice alice@example.com Alice alice@example.com mallory@example.com
+expect_fail "mismatched human sign-off" alice
+
+create_case body-only-signoff
+add_commit Alice alice@example.com Alice alice@example.com alice@example.com \
+  'This paragraph means the preceding line is body text, not a trailer.'
+expect_fail "Signed-off-by outside the trailer block" alice
+
+dependabot_json='{
+  "author": {"login": "dependabot[bot]"},
+  "committer": {"login": "web-flow"},
+  "verification": {"verified": true, "reason": "valid"}
+}'
+
+create_case verified-dependabot
+add_commit 'dependabot[bot]' \
+  '49699333+dependabot[bot]@users.noreply.github.com' \
+  GitHub noreply@github.com support@github.com
+expect_pass "verified canonical Dependabot commit" 'dependabot[bot]' "$dependabot_json"
+expect_fail "Dependabot commit on a non-Dependabot PR" alice "$dependabot_json"
+
+unverified_dependabot_json='{
+  "author": {"login": "dependabot[bot]"},
+  "committer": {"login": "web-flow"},
+  "verification": {"verified": false, "reason": "unsigned"}
+}'
+expect_fail "unverified Dependabot commit" 'dependabot[bot]' "$unverified_dependabot_json"
+
+wrong_api_identity_json='{
+  "author": {"login": "renovate[bot]"},
+  "committer": {"login": "web-flow"},
+  "verification": {"verified": true, "reason": "valid"}
+}'
+expect_fail "mismatched GitHub API identity" 'dependabot[bot]' "$wrong_api_identity_json"
+
+create_case missing-signoff
+add_commit Alice alice@example.com Alice alice@example.com
+expect_fail "missing sign-off" alice
+
+echo "DCO policy tests passed"

--- a/test/ci/release_image_gate_test.mjs
+++ b/test/ci/release_image_gate_test.mjs
@@ -44,6 +44,19 @@ assert.doesNotMatch(buildSection, /:main/);
 assert.match(release, /imagetools create --prefer-index=false --tag "\$IMAGE:main"/);
 assert.match(release, /test "\$promoted_digest" = "\$DIGEST"/);
 
+const sourceEvidenceSection = release.slice(
+  release.indexOf("- name: Verify and collect the source release evidence"),
+  release.indexOf("- name: Archive the source release, SPDX SBOM, and attestation"),
+);
+assert.match(sourceEvidenceSection, /gh attestation verify "\$archive"/);
+assert.match(sourceEvidenceSection, /--bundle "\$ATTESTATION_BUNDLE"/);
+assert.match(sourceEvidenceSection, /--predicate-type https:\/\/spdx\.dev\/Document\/v2\.3/);
+assert.match(
+  sourceEvidenceSection,
+  /--cert-identity "https:\/\/github\.com\/\$GITHUB_REPOSITORY\/\.github\/workflows\/release\.yml@refs\/heads\/main"/,
+);
+assert.match(sourceEvidenceSection, /--deny-self-hosted-runners/);
+
 for (const source of [release, deploy]) {
   assert.match(source, /--predicate-type https:\/\/burnerpad\.io\/attestations\/trivy\/v1/);
 }


### PR DESCRIPTION
Consolidate the five GitHub Actions updates, accept only canonical GitHub-verified Dependabot sign-offs, and group future Actions updates.

Verify source SBOM attestations from the local bundle with the exact SPDX predicate and release workflow identity.